### PR TITLE
Fix layout issues and add GitHub sponsorship

### DIFF
--- a/components/completedProjectList.tsx
+++ b/components/completedProjectList.tsx
@@ -6,14 +6,16 @@ import { ProjectListProp } from '../types/Projects'
 function CompletedProjectList({ projects }: ProjectListProp) {
   return (
     <>
-      <Heading variant="projectSection">Completed Works</Heading>
+      <Heading as="h2" size="xl" mt={10}>
+        Completed Works
+      </Heading>
       <Text maxW={{ base: '90%', md: '100%' }} style={{ textAlign: 'center' }}>
         Here are a few of our complete work. For all of our projects visit our
         <Link> Github Page</Link>.
       </Text>
       <SimpleGrid
         minChildWidth={{ md: '45%' }}
-        w={{ base: '100%', md: '50%' }}
+        w={{ base: '100%', md: '80%' }}
         mt={{ base: '5%', md: '2%' }}
         justifyItems={{ base: 'center' }}
         spacing="1%"

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -25,7 +25,7 @@ type FooterItems = SocialLink & {
 
 const SocialLink = ({ children, label, href }: SocialLink) => {
   return (
-    <Link href={href} variant="socialLink">
+    <Link href={href} variant="socialLink" fontSize={'1.5em'}>
       <VisuallyHidden>{label}</VisuallyHidden>
       {children}
     </Link>
@@ -39,7 +39,7 @@ const ListHeader = ({ children }: { children: ReactNode }) => {
 const ListLink = ({ children, href }: LinkProps) => {
   return (
     <Link href={href}>
-      <Text variant="fll">{children}</Text>
+      <Text>{children}</Text>
     </Link>
   )
 }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -7,9 +7,11 @@ import {
   Text,
   VisuallyHidden,
   useColorModeValue,
+  useBreakpointValue,
+  Heading,
 } from '@chakra-ui/react'
 import { ReactNode } from 'react'
-import { FaLinkedin, FaTwitter, FaYoutube } from 'react-icons/fa'
+import { FaGithub, FaLinkedin, FaTwitter, FaYoutube } from 'react-icons/fa'
 import { Link, LinkProps } from './link'
 
 type SocialLink = LinkProps & {
@@ -31,7 +33,7 @@ const SocialLink = ({ children, label, href }: SocialLink) => {
 }
 
 const ListHeader = ({ children }: { children: ReactNode }) => {
-  return <Text variant="flh">{children}</Text>
+  return <Heading as="h2">{children}</Heading>
 }
 
 const ListLink = ({ children, href }: LinkProps) => {
@@ -43,7 +45,8 @@ const ListLink = ({ children, href }: LinkProps) => {
 }
 
 const FOOTER_ITEMS_COMPANY: ReadonlyArray<FooterItems> = [
-  { href: '#', label: 'About', key: 'About' },
+  { href: 'about', label: 'About', key: 'About' },
+  { href: 'portfolio', label: 'Portfolio', key: 'Portfolio' },
   {
     href: 'mailto:info@open-austin.org',
     label: 'Contact us',
@@ -54,8 +57,13 @@ const FOOTER_ITEMS_COMPANY: ReadonlyArray<FooterItems> = [
 const FOOTER_ITEMS_SUPPORT: ReadonlyArray<FooterItems> = [
   {
     href: 'https://opencollective.com/open-austin',
-    label: 'Donate',
-    key: 'donate',
+    label: 'Open Collective',
+    key: 'oc',
+  },
+  {
+    href: 'https://github.com/sponsors/open-austin',
+    label: 'GitHub Sponsor',
+    key: 'github',
   },
 ]
 
@@ -78,6 +86,12 @@ const SOCIAL_ITEMS: ReadonlyArray<FooterItems> = [
     icon: <FaLinkedin />,
     key: 'linkedin',
   },
+  {
+    label: 'GitHub',
+    href: 'https://github.com/open-austin',
+    icon: <FaGithub />,
+    key: 'github',
+  },
 ]
 
 export default function LargeWithNewsletter() {
@@ -86,13 +100,37 @@ export default function LargeWithNewsletter() {
       bg={useColorModeValue('gray.50', 'gray.900')}
       color={useColorModeValue('gray.700', 'gray.200')}
     >
-      <Container as={Stack} maxW={'6xl'} py={10}>
+      <Container
+        as={Stack}
+        maxW={'6xl'}
+        py={useBreakpointValue({ base: 4, md: 10 })}
+      >
         <SimpleGrid
-          templateColumns={{ base: '1fr 1fr', md: '2fr 1fr 1fr 2fr' }}
-          templateRows={{ base: '1fr 1fr 1fr', md: '1fr' }}
+          templateColumns={{ base: '1fr 1fr', md: '2fr 1fr 1fr' }}
+          templateRows={{ base: '1fr 1fr', md: '1fr' }}
           spacing={8}
         >
-          <Stack spacing={6} gridColumn={{ base: '1 / -1', md: '1' }}>
+          <Stack order={useBreakpointValue({ base: 1, md: 2 })}>
+            <ListHeader>More Info</ListHeader>
+            {FOOTER_ITEMS_COMPANY.map((link) => (
+              <ListLink href={link.href} key={link.key}>
+                {link.label}
+              </ListLink>
+            ))}
+          </Stack>
+          <Stack order={useBreakpointValue({ base: 2, md: 3 })}>
+            <ListHeader>Support</ListHeader>
+            {FOOTER_ITEMS_SUPPORT.map((link) => (
+              <ListLink href={link.href} key={link.key}>
+                {link.label}
+              </ListLink>
+            ))}
+          </Stack>
+          <Stack
+            spacing={6}
+            gridColumn={{ base: '1 / -1', md: '1' }}
+            order={useBreakpointValue({ base: 3, md: 1 })}
+          >
             <Box alignSelf="center">
               <Image
                 alt="Open Austin's logo; a five-pointed star in orange and black"
@@ -112,22 +150,6 @@ export default function LargeWithNewsletter() {
                 </SocialLink>
               ))}
             </Stack>
-          </Stack>
-          <Stack>
-            <ListHeader>Company</ListHeader>
-            {FOOTER_ITEMS_COMPANY.map((link) => (
-              <ListLink href={link.href} key={link.key}>
-                {link.label}
-              </ListLink>
-            ))}
-          </Stack>
-          <Stack>
-            <ListHeader>Support</ListHeader>
-            {FOOTER_ITEMS_SUPPORT.map((link) => (
-              <ListLink href={link.href} key={link.key}>
-                {link.label}
-              </ListLink>
-            ))}
           </Stack>
         </SimpleGrid>
       </Container>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -13,7 +13,7 @@ import {
 import { Link } from './link'
 
 const Hero = () => (
-  <Flex w={'100vw'} h={'calc(100vh - 335px)'} pos="relative">
+  <Flex minH={'calc(100vh - 335px)'} pos="relative">
     <Image
       priority
       alt="Gathering of volunteers at an Open Austin event"
@@ -26,67 +26,57 @@ const Hero = () => (
       w={'full'}
       zIndex={1}
       justify={'center'}
-      px={useBreakpointValue({ base: 4, md: 8 })}
       bgGradient={'linear(to-r, blackAlpha.600, transparent)'}
     >
-      <Stack
-        maxW={'3xl'}
-        align={'flex-start'}
-        spacing={6}
-        justifyContent="center"
-        alignItems={'center'}
+      <Box
+        boxShadow="2xl"
+        maxW={useBreakpointValue({ base: 'full', md: 600 })}
+        p={useBreakpointValue({ base: 4, md: 12 })}
+        rounded="md"
+        bgColor={'blackAlpha.300'}
       >
-        <Box
-          boxShadow="2xl"
-          p="12"
-          rounded="md"
-          bg="white"
-          bgColor={'blackAlpha.300'}
+        <Heading
+          as="h1"
+          color={'orange.300'}
+          textAlign="center"
+          fontSize={useBreakpointValue({ base: '6xl', md: '7xl' })}
+          fontWeight={900}
         >
-          <Heading
-            as="h1"
-            color={'orange.300'}
-            textAlign="center"
-            fontSize={useBreakpointValue({ base: '6xl', md: '7xl' })}
-            fontWeight={900}
-          >
-            Open Austin
-          </Heading>
-          <Text
-            color={'gray.200'}
-            align="center"
-            fontWeight={500}
-            lineHeight={1.2}
-            p={4}
-            fontSize={useBreakpointValue({ base: 'xl', md: 'lg' })}
-          >
-            Open Austin addresses local social and civic challenges through
-            creative uses of technology. We foster relationships between
-            government, non- and for-profit organizations, and resident
-            activists.
-          </Text>
+          Open Austin
+        </Heading>
+        <Text
+          color={'gray.200'}
+          align="center"
+          fontWeight={500}
+          lineHeight={1.2}
+          p={4}
+          fontSize={useBreakpointValue({ base: 'xl', md: 'lg' })}
+        >
+          Open Austin addresses local social and civic challenges through
+          creative uses of technology. We foster relationships between
+          government, non- and for-profit organizations, and resident activists.
+        </Text>
 
-          <Heading
-            as="h2"
-            color={'gray.100'}
-            textAlign="center"
-            fontSize={useBreakpointValue({ base: '3xl', md: '5xl' })}
-            fontWeight={700}
-            pb={4}
-          >
-            All are welcome!
-          </Heading>
+        <Heading
+          as="h2"
+          color={'gray.100'}
+          textAlign="center"
+          fontSize={useBreakpointValue({ base: '3xl', md: '5xl' })}
+          fontWeight={700}
+          pb={4}
+        >
+          All are welcome!
+        </Heading>
 
-          <Stack direction={'row'} align={'flex-end'} justifyContent="center">
-            <Link href="about">
-              <Button variant="primary">About</Button>
-            </Link>
-            <Link href="portfolio">
-              <Button variant="primary">Projects</Button>
-            </Link>
-          </Stack>
-        </Box>
-      </Stack>
+        <Stack direction={'row'} align={'flex-end'} justifyContent="center">
+          <Link href="about">
+            <Button variant="primary">About</Button>
+          </Link>
+          <Link href="portfolio">
+            <Button variant="primary">Projects</Button>
+          </Link>
+        </Stack>
+      </Box>
     </VStack>
   </Flex>
 )

--- a/components/projectHeader.tsx
+++ b/components/projectHeader.tsx
@@ -8,7 +8,7 @@ const ProjectHeader = () => {
       flexDirection={{ base: 'column' }}
       alignItems={{ base: 'center' }}
       justifyContent={{ base: 'space-around' }}
-      height={{ base: '10rem' }}
+      gap={4}
     >
       <Heading variant="title">Projects</Heading>
       <Text style={{ textAlign: 'center' }} fontSize="xl">

--- a/components/wipProjectList.tsx
+++ b/components/wipProjectList.tsx
@@ -6,13 +6,15 @@ import { ProjectListProp } from '../types/Projects'
 function WipProjectList({ projects }: ProjectListProp) {
   return (
     <>
-      <Heading variant="projectSection">Works in Progress</Heading>
+      <Heading as="h2" size="xl" mt={10}>
+        Works in Progress
+      </Heading>
       <SimpleGrid
         minChildWidth={{ md: '45%' }}
-        w={{ base: '100%', md: '50%' }}
+        w={{ base: 'full', md: '80%' }}
         mt={{ base: '5%', md: '2%' }}
         justifyItems={{ base: 'center' }}
-        spacing="1%"
+        spacing={4}
       >
         {projects.map((project) => (
           <ProjectCard project={project} key={project.title} />

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -143,7 +143,6 @@ const components = {
       projectSection: {
         fontSize: fontSizes['3xl'],
         pt: 8,
-        marginTop: '5%',
       },
       credits: {
         fontSize: fontSizes['3xl'],
@@ -154,18 +153,6 @@ const components = {
   Text: {
     baseStyle: {
       fontSize: fontSizes['xl'],
-    },
-    variants: {
-      // footer link header
-      flh: {
-        fontWeight: '500',
-        fontSize: 'lg',
-        mb: 2,
-      },
-      // footer list link
-      fll: {
-        fontSize: fontSizes['md'],
-      },
     },
   },
 }


### PR DESCRIPTION
This makes a few improvements:

- Hero section was messed up in mobile view
- Footer links were small
- `Project` cards were kind of dense
- Adds link to GitHub sponsors page in the footer section

You can see the differences by comparing current https://www.open-austin.org site with [this preview](https://website-v2-b2dgsz2vj-open-austin-vercel.vercel.app/).