### PR TITLE
[#63] Adjust margin-bottom for portfolio container

### DIFF
--- a/pages/portfolio.tsx
+++ b/pages/portfolio.tsx
@@ -4,7 +4,7 @@ import ProjectHeader from '../components/projectHeader'
 
 const Portfolio = () => {
   return (
-    <Container maxW="container.lg" mb={{ base: '50%', md: '15%' }}>
+    <Container maxW="container.lg" mb={{ base: '90%', md: '15%' }}>
       <Flex flexDirection="column" alignItems="center" my="5%">
         <ProjectHeader />
         <ProjectList />


### PR DESCRIPTION
Fixes https://github.com/open-austin/website-v2-vercel/issues/63 so footer doesn't overlap on mobile layout

<img width="534" alt="Screenshot 2023-05-23 at 5 06 21 PM" src="https://github.com/open-austin/website-v2-vercel/assets/15278020/40364024-20b3-4217-9b1e-2fa434906c8e">
