### PR TITLE
[#61] Remove code for america and replace with civic technologists link

### DIFF
--- a/pages/how-to-get-involved.tsx
+++ b/pages/how-to-get-involved.tsx
@@ -14,14 +14,17 @@ const GetInvolved = () => {
           </Link>{' '}
           to work on technology and design projects that positively impact
           public policy and our communities. We amplify the initiatives of other
-          Austin-based civic organizations, and we collaborate with other
-          chapters of the{' '}
-          <Link href="https://brigade.codeforamerica.org/" isExternal>
-            Code for America Brigade Network
-          </Link>{' '}
-          and the broader civic tech community via our{' '}
+          Austin-based civic organizations, and we collaborate with the broader
+          civic tech community via our{' '}
           <Link href="https://github.com/open-austin" isExternal>
             GitHub organization
+          </Link>
+          .
+        </Text>
+        <Text>
+          We are part of the{' '}
+          <Link href="http://www.civictechnologists.org/" isExternal>
+            Alliance of Civic Technologists
           </Link>
           .
         </Text>

--- a/pages/mission-statement.tsx
+++ b/pages/mission-statement.tsx
@@ -21,7 +21,7 @@ const MissionStatement = () => {
         py={{ base: 20, md: 28 }}
         direction={{ base: 'column', md: 'row' }}
       >
-        <Stack flex={1} spacing={{ base: 5, md: 10 }}>
+        <Stack flex={1}>
           <Heading lineHeight={1.1} fontWeight={600} variant="title">
             Mission Statement
           </Heading>
@@ -33,11 +33,10 @@ const MissionStatement = () => {
             creatively to address local civic and social challenges, and improve
             all our neighbors’ quality of life.
           </Text>
-
-          <Text as={'span'}>
-            We are affiliated with{' '}
-            <Link href="https://brigade.codeforamerica.org/" isExternal>
-              Code for America’s Brigade Network
+          <Text>
+            We are part of the{' '}
+            <Link href="http://www.civictechnologists.org/" isExternal>
+              Alliance of Civic Technologists
             </Link>
             .
           </Text>


### PR DESCRIPTION
Fixes #61

Removes Code for America links and replaces them with a new link to the Civic Technologists website after confirming with @lianilychee. 

The exception is the code of conduct page where we want to keep the link to Code for America's code of conduct.
