### PR TITLE
Slack Invite Link Workaround - Issue #46

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -308,7 +308,7 @@ const NAV_ITEMS: ReadonlyArray<NavItem> = [
       {
         label: 'Join Slack',
         href: 'mailto:info@open-austin.org?subject=Join%20Slack%20Request',
-        subLabel: 'To recieve the slack invite link, please send an email to info@open-austin.org with "Join Slack Request" as the Subject.',
+        subLabel: 'To recieve the slack invite link, please send an email to info@open-austin.org',
         external: true,
       },
       {

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -307,7 +307,8 @@ const NAV_ITEMS: ReadonlyArray<NavItem> = [
     children: [
       {
         label: 'Join Slack',
-        href: 'https://slack.open-austin.org/',
+        href: 'mailto:info@open-austin.org?subject=Join%20Slack%20Request',
+        subLabel: 'To recieve the slack invite link, please send an email to info@open-austin.org with "Join Slack Request" as the Subject.',
         external: true,
       },
       {


### PR DESCRIPTION
After speaking with @lianilychee further, we had to scale back the slack invite link due to the api only being accessible to enterprise level slack customers.

Our workaround is to send the invite link out as part of the automated reply when someone emails info@open-austin.org. This is more secure than adding the link on the website.

The invite link will be set to "never expire" which will work for 400 users.