### PR TITLE
Fix donate button to open in new window

### DIFF
--- a/components/donateButton.tsx
+++ b/components/donateButton.tsx
@@ -1,17 +1,15 @@
-import Link from 'next/link'
 import { Button } from '@chakra-ui/react'
 
 export default function DonateButton() {
   return (
-    <Link
+    <a
       href="https://opencollective.com/open-austin"
       target="_blank"
       rel="noreferrer"
-      passHref
     >
       <Button variant="primary" display={{ base: 'none', md: 'inline-flex' }} as="a">
         Donate
       </Button>
-    </Link>
+    </a>
   )
 }


### PR DESCRIPTION
Link component from next/link is designed for client-side navigation within the Next.js application. It's not meant for external links and doesn't support the target attribute '_blank'

Change the link element to an anchor tag. The donate button is now opening in a new window. #82 